### PR TITLE
add raylib submodule @ 3.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "raylib"]
+	path = raylib
+	url = https://github.com/raysan5/raylib

--- a/build.zig
+++ b/build.zig
@@ -58,13 +58,15 @@ pub fn build(b: *Builder) void {
     };
 
     const examples_step = b.step("examples", "Builds all the examples");
+    const system_lib = b.option(bool, "system-raylib", "link to preinstalled raylib libraries") orelse false;
 
     for (examples) |ex| {
         const exe = b.addExecutable(ex.name, ex.path);
+
         exe.setBuildMode(mode);
         exe.setTarget(target);
 
-        raylib.link(exe);
+        raylib.link(exe, system_lib);
         raylib.addAsPackage("raylib", exe);
         raylib.math.addAsPackage("raylib-math", exe);
 

--- a/lib.zig
+++ b/lib.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const Builder = std.build.Builder;
+const LibExeObjStep = std.build.LibExeObjStep;
+
+pub fn Pkg(pkgdir: comptime []const u8) type {
+    return struct {
+        pub fn link(exe: *LibExeObjStep) void {
+            const raylibFlags = &[_][]const u8{
+                "-std=c99",
+                "-DPLATFORM_DESKTOP",
+                "-D_POSIX_C_SOURCE",
+            };
+            if (exe.target.toTarget().os.tag == .windows) {
+                exe.linkSystemLibrary("winmm");
+                exe.linkSystemLibrary("gdi32");
+            } else {
+                exe.linkSystemLibrary("m");
+                exe.linkSystemLibrary("X11");
+            }
+            exe.linkLibC();
+
+            exe.addSystemIncludeDir(pkgdir ++ "/raylib/src");
+            exe.addSystemIncludeDir(pkgdir ++ "/raylib/src/external/glfw/include");
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/core.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/models.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/raudio.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/rglfw.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/shapes.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/text.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/textures.c", raylibFlags);
+            exe.addCSourceFile(pkgdir ++ "/raylib/src/utils.c", raylibFlags);
+        }
+        pub fn addAsPackage(name: comptime []const u8, to: *LibExeObjStep) void {
+            to.addPackagePath(name, pkgdir ++ "/lib/raylib-zig.zig");
+        }
+        pub const math = struct {
+            pub fn addAsPackage(name: comptime []const u8, to: *LibExeObjStep) void {
+                to.addPackagePath(name, pkgdir ++ "/lib/raylib-zig-math.zig");
+            }
+        };
+    };
+}

--- a/lib.zig
+++ b/lib.zig
@@ -10,7 +10,7 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                 "-std=c99",
                 "-DPLATFORM_DESKTOP",
                 "-D_POSIX_C_SOURCE",
-                "-DGL_SILENCE_DEPRECATION"
+                "-DGL_SILENCE_DEPRECATION",
             };
             const target_os = exe.target.toTarget().os.tag;
             switch (target_os) {
@@ -19,21 +19,12 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                     exe.linkSystemLibrary("gdi32");
                     exe.linkSystemLibrary("opengl32");
                 },
-                .macosx => {
-                    var buffer: [100]u8 = undefined;
-
-                    const frameworkDir = std.fmt.bufPrint(buffer[0..], "/Library/Developer/CommandLineTools/SDKs/MACOSX{}.{}.sdk/System/Library/Frameworks", .{
-                        exe.target.toTarget().os.version_range.semver.max.major,
-                        exe.target.toTarget().os.version_range.semver.max.minor,
-                    }) catch unreachable;
-
-                    exe.addFrameworkDir(frameworkDir);
-                    exe.linkSystemLibrary("glfw");
-                    exe.linkFramework("OpenGL");
-                    exe.linkFramework("Cocoa");
-                    exe.linkFramework("IOKit");
-                    exe.linkFramework("CoreAudio");
-                    exe.linkFramework("CoreVideo");
+                .macosx => if (system_lib) {
+                    std.debug.warn("TODO: add libraries necessary for system_lib linking on macosx (maybe just glfw?)", .{});
+                    std.os.exit(1);
+                } else {
+                    std.debug.warn("compiling raylib is unsupported on macosx\n", .{});
+                    std.os.exit(1);
                 },
                 .freebsd, .openbsd, .netbsd, .dragonfly => {
                     exe.linkSystemLibrary("GL");

--- a/lib.zig
+++ b/lib.zig
@@ -18,6 +18,10 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                     exe.linkSystemLibrary("winmm");
                     exe.linkSystemLibrary("gdi32");
                     exe.linkSystemLibrary("opengl32");
+                    // build vendored glfw as well
+                    exe.addIncludeDir(pkgdir ++ "/raylib/src/external/glfw/include");
+                    exe.addIncludeDir(pkgdir ++ "/raylib/src/external/glfw/deps/mingw");
+                    exe.addCSourceFile(pkgdir ++ "/raylib/src/rglfw.c", raylibFlags);
                 },
                 .macosx => if (system_lib) {
                     std.debug.warn("TODO: add libraries necessary for system_lib linking on macosx (maybe just glfw?)", .{});
@@ -27,6 +31,7 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                     std.os.exit(1);
                 },
                 .freebsd, .openbsd, .netbsd, .dragonfly => {
+                    exe.linkSystemLibrary("glfw");
                     exe.linkSystemLibrary("GL");
                     exe.linkSystemLibrary("rt");
                     exe.linkSystemLibrary("dl");
@@ -39,6 +44,7 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                     exe.linkSystemLibrary("Xcursor");
                 },
                 else => { // linux and possibly others
+                    exe.linkSystemLibrary("glfw");
                     exe.linkSystemLibrary("GL");
                     exe.linkSystemLibrary("rt");
                     exe.linkSystemLibrary("dl");
@@ -61,12 +67,9 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
             , .{});
 
             exe.addIncludeDir(pkgdir ++ "/raylib/src");
-            exe.addIncludeDir(pkgdir ++ "/raylib/src/external/glfw/include");
-            exe.addIncludeDir(pkgdir ++ "/raylib/src/external/glfw/deps/mingw");
+
             exe.addCSourceFile(pkgdir ++ "/raylib/src/core.c", raylibFlags);
             exe.addCSourceFile(pkgdir ++ "/raylib/src/models.c", raylibFlags);
-            if (target_os != .macosx)
-                exe.addCSourceFile(pkgdir ++ "/raylib/src/rglfw.c", raylibFlags);
             exe.addCSourceFile(pkgdir ++ "/raylib/src/raudio.c", raylibFlags);
             exe.addCSourceFile(pkgdir ++ "/raylib/src/shapes.c", raylibFlags);
             exe.addCSourceFile(pkgdir ++ "/raylib/src/text.c", raylibFlags);

--- a/lib.zig
+++ b/lib.zig
@@ -11,12 +11,38 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                 "-D_POSIX_C_SOURCE",
             };
 
-            if (exe.target.toTarget().os.tag == .windows) {
-                exe.linkSystemLibrary("winmm");
-                exe.linkSystemLibrary("gdi32");
-            } else {
-                exe.linkSystemLibrary("m");
-                exe.linkSystemLibrary("X11");
+            switch (exe.target.toTarget().os.tag) {
+                .windows => {
+                    exe.linkSystemLibrary("winmm");
+                    exe.linkSystemLibrary("gdi32");
+                    exe.linkSystemLibrary("opengl32");
+                },
+                .macosx => {
+                    exe.linkFramework("OpenGL");
+                    exe.linkFramework("Cocoa");
+                    exe.linkFramework("IOKit");
+                    exe.linkFramework("CoreAudio");
+                    exe.linkFramework("CoreVideo");
+                },
+                .freebsd, .netbsd, .dragonfly => {
+                    exe.linkSystemLibrary("GL");
+                    exe.linkSystemLibrary("rt");
+                    exe.linkSystemLibrary("dl");
+                    exe.linkSystemLibrary("m");
+                    exe.linkSystemLibrary("X11");
+                    exe.linkSystemLibrary("Xrandr");
+                    exe.linkSystemLibrary("Xinerama");
+                    exe.linkSystemLibrary("Xi");
+                    exe.linkSystemLibrary("Xxf86vm");
+                    exe.linkSystemLibrary("Xcursor");
+                },
+                else => { // linux and possibly others
+                    exe.linkSystemLibrary("GL");
+                    exe.linkSystemLibrary("rt");
+                    exe.linkSystemLibrary("dl");
+                    exe.linkSystemLibrary("m");
+                    exe.linkSystemLibrary("X11");
+                },
             }
             exe.linkLibC();
 

--- a/lib.zig
+++ b/lib.zig
@@ -10,6 +10,7 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                 "-std=c99",
                 "-DPLATFORM_DESKTOP",
                 "-D_POSIX_C_SOURCE",
+                "-DGL_SILENCE_DEPRECATION"
             };
             const target_os = exe.target.toTarget().os.tag;
             switch (target_os) {

--- a/lib.zig
+++ b/lib.zig
@@ -4,12 +4,13 @@ const LibExeObjStep = std.build.LibExeObjStep;
 
 pub fn Pkg(pkgdir: comptime []const u8) type {
     return struct {
-        pub fn link(exe: *LibExeObjStep) void {
+        pub fn link(exe: *LibExeObjStep, system_lib: bool) void {
             const raylibFlags = &[_][]const u8{
                 "-std=c99",
                 "-DPLATFORM_DESKTOP",
                 "-D_POSIX_C_SOURCE",
             };
+
             if (exe.target.toTarget().os.tag == .windows) {
                 exe.linkSystemLibrary("winmm");
                 exe.linkSystemLibrary("gdi32");
@@ -18,6 +19,11 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                 exe.linkSystemLibrary("X11");
             }
             exe.linkLibC();
+
+            if (system_lib) {
+                exe.linkSystemLibrary("raylib");
+                return;
+            }
 
             exe.addSystemIncludeDir(pkgdir ++ "/raylib/src");
             exe.addSystemIncludeDir(pkgdir ++ "/raylib/src/external/glfw/include");
@@ -30,6 +36,7 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
             exe.addCSourceFile(pkgdir ++ "/raylib/src/textures.c", raylibFlags);
             exe.addCSourceFile(pkgdir ++ "/raylib/src/utils.c", raylibFlags);
         }
+
         pub fn addAsPackage(name: comptime []const u8, to: *LibExeObjStep) void {
             to.addPackagePath(name, pkgdir ++ "/lib/raylib-zig.zig");
         }

--- a/lib.zig
+++ b/lib.zig
@@ -84,9 +84,9 @@ pub fn Pkg(pkgdir: comptime []const u8) type {
                 std.debug.warn("unable to create child process for git. build interrupted\n", .{});
                 std.os.exit(1);
             };
-
+            git_proc.cwd = pkgdir;
             const term = git_proc.spawnAndWait() catch {
-                std.debug.warn("unable to spawn child processfor git. build interrupted\n", .{});
+                std.debug.warn("unable to spawn child process for git. build interrupted\n", .{});
                 std.os.exit(1);
             };
 


### PR DESCRIPTION
also add build helper `lib.zig` to handle compiling and linking against raylib's source code and using raylib-zig from a sub-directory of a project more easily. Modifies `build.zig` for examples to reflect lib.zig usage. 

Tested cross compilation to x86_64-windows-gnu, and on alpine linux natively. Building natively on linux requires the user to pull in a bunch of X11 development packages; XLib, xinput, xinerama, etc.

checklist

- [X] option to link against system libraries
- [X] machinery to automatically initialize and update the the submodule
~~basic interface to c #define options for raylib~~ *can be built out as declarative configuration later*
- [x] update projectSetup.sh
- ~~have the macosx stuff figure out how to add the system's sdk framework directory~~