### PR TITLE
Fixes GenGradientV duplication

### DIFF
--- a/lib/raylib-zig.zig
+++ b/lib/raylib-zig.zig
@@ -140,8 +140,8 @@ pub const Image = extern struct {
         return GenImageGradientV(width, height, top, bottom);
     }
 
-    pub fn GenGradientV(width: c_int, height: c_int, left: Color, right: Color) Image {
-        return GenImageGradientV(width, height, left, right);
+    pub fn GenGradientH(width: c_int, height: c_int, left: Color, right: Color) Image {
+        return GenImageGradientH(width, height, left, right);
     }
 
     pub fn GenGradientRadial(width: c_int, height: c_int, density: f32, inner: Color, outer: Color) Image {


### PR DESCRIPTION
The function GenGradientV was duplicated which caused a compiler error when using other calling functions.